### PR TITLE
set orientation when image is from camera

### DIFF
--- a/UzysImageCropper/Library/UzysImageCropper.m
+++ b/UzysImageCropper/Library/UzysImageCropper.m
@@ -352,7 +352,7 @@
     
     UIImage *rotInputImage = [_inputImage imageRotatedByRadians:rotationZ];
     CGImageRef tmp = CGImageCreateWithImageInRect([rotInputImage CGImage], CropRectinImage);
-    UIImage *newImage = [UIImage imageWithCGImage:tmp];
+    UIImage *newImage = [UIImage imageWithCGImage:tmp scale:self.inputImage.scale orientation:self.inputImage.imageOrientation];
     CGImageRelease(tmp);
     
     if(newImage.size.width != _realCropsize.width)


### PR DESCRIPTION
When I use from UIImagePickerController and crop image from camera, sometimes image rotate 90 degree because of jpeg EXIF data. (see this: http://stackoverflow.com/questions/3554244/uiimagepngrepresentation-issues-images-rotated-by-90-degrees)

so in getCroppedImage method I modified [UIImage  imageWithCGImage:] to [UIImage imageWithCGImage: scale: orientation:]
